### PR TITLE
Added two new example queries:

### DIFF
--- a/examples/länka-uppdrag-lämningar.ru
+++ b/examples/länka-uppdrag-lämningar.ru
@@ -1,0 +1,41 @@
+# Skapa länkar mellan uppdarag i testservern och lämningar från FMIS/K-samsök enligt CIDOC-CRMs arkeologiskt tillägg:
+prefix fmis: <http://kulturarvsdata.se/raa/fmi/>
+prefix uppdrag: <https://kulturarvsdata.se/aktivitet/uppdrag/>
+prefix crm-archaeo: <http://www.ics.forth.gr/isl/CRMarchaeo/>
+
+INSERT DATA {
+uppdrag:cc0e86a4-a27d-4b93-930b-499637d38ba6 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500140001 .
+uppdrag:2f610f5c-e209-41e4-b2e2-c3ddb955f240 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500180002 .
+uppdrag:78144c3b-eeb1-45e7-bcdc-967bd8713931 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100400960001 .
+uppdrag:592803aa-fbba-4214-b8d7-31b09367c08c a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100600510001 .
+uppdrag:6d9428b7-421e-46c6-b985-f7edd1f4740c a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500180001 .
+uppdrag:f7a706fa-6657-4a6e-8058-84787ec773ad a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:12000000140794 .
+uppdrag:acd3d7e4-60af-4f24-9df9-b516d5ff07ad a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10102000580001 .
+uppdrag:a0241664-2859-4235-84b8-b40de88ec642 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101400130001 .
+uppdrag:7fbed1d3-6ae3-4871-b643-a91483e156ff a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100500130002 .
+uppdrag:9330c24d-0029-409d-be77-8777d3f2279c a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100500130001 .
+uppdrag:224f00b1-c855-48a6-9ae1-70b1b5a4b3ca a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500250001 .
+uppdrag:73ad0e95-442e-4892-9e26-6677ed7566ad a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500180002 .
+uppdrag:a00ee8e9-f7ca-4e92-9460-43d74eabf492 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500180001 .
+uppdrag:b2551245-e496-44b8-ba4c-982fd159c7fd a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10101500140001 .
+uppdrag:90dfa6e3-72eb-4dfe-accf-68284777b8e9 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100600510001 .
+uppdrag:4c654afa-cf66-4c50-99db-4990921465e9 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100400960001 .
+uppdrag:0965ed13-0812-47eb-8df9-e4019566a7f4 a crm-archaeo:A1_Excavation_Process_Unit ;
+                                             crm-archaeo:AP3_excavated fmis:10100400960001 .
+}

--- a/examples/uppdrag-lämning-verk.rq
+++ b/examples/uppdrag-lämning-verk.rq
@@ -1,0 +1,33 @@
+# Federated query tvärs ett uppdragsregister, lämningsregister, och Libris.
+# För ett uppdrag, visa dess uppdragstyp, namnet på utförande organisationen, ärendenummret hos länsstyrelsen, vilka sorters lämningar (lämningstyper) undersöktes, och titel + förefattare för böcker/artiklar som har skrivits om lämningarna:
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix fmis: <http://kulturarvsdata.se/raa/fmi/>
+prefix soch: <http://kulturarvsdata.se/ksamsok#>
+#prefix libris: <http://libris.kb.se/resource/bib/>
+prefix dc: <http://purl.org/dc/elements/1.1/>
+#prefix uppdragstyp: <http://kulturarvsdata.se/aktivitet/arkeologisktuppdrag/>
+prefix egenskap: <https://kulturarvsdata.se/egenskap/>
+prefix crm-archaeo: <http://www.ics.forth.gr/isl/CRMarchaeo/>
+#prefix crm-sci: <http://www.ics.forth.gr/isl/CRMsci/>
+#prefix crm: <http://www.cidoc-crm.org/cidoc-crm/>
+#prefix geo: <http://www.opengis.net/ont/geosparql#>
+
+SELECT DISTINCT ?uppdrag ?uppdragstyp ?utförarenamn ?ärende ?lämningsetikett ?titel ?författare
+WHERE {
+  ?uppdrag crm-archaeo:AP3_excavated ?lämning .
+  ?lämning soch:isDescribedBy ?verk ;
+           soch:itemLabel ?lämningsetikett .
+  # Här ersätter vi de felaktiga <http://libris.kb.se/bib/> URIer vi har med korrekta <http://libris.kb.se/resource/bib/> sådana:
+  BIND(URI(REPLACE(STR(?verk), 'se/bib/', 'se/resource/bib/')) as ?verk2) .
+  SERVICE <http://libris.kb.se/sparql> {
+	?verk2 dc:creator ?författare ;
+           dc:title ?titel .
+  }
+  SERVICE <http://ul-tonilabb01.testraa.se:8080/blazegraph/namespace/raa.se/sparql> {
+	?uppdrag rdf:type ?uppdragstyp ;
+	         egenskap:utförare ?utförare ;
+	         egenskap:ärende ?ärende .
+    ?utförare egenskap:namn ?utförarenamn .
+  }
+}
+


### PR DESCRIPTION
- An `INSERT` query to create links between monuments in a monuments register and investigations in a fieldwork register;
- A federated query combining data across a monuments register, a fieldwork register, and the Swedish National Library.
